### PR TITLE
Removed the ID parameter from /rest/v1/afspraken

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,6 @@ Fetch the appointments from the schedule of the student.
 
 | Name          | Type      | Value                 |
 | ------------- | --------- | --------------------- |
-| id            | URL       | [user id]             |
 | Authorization | Header    | Bearer [access_token] |
 | sort          | Parameter | asc-id                |
 | additional    | Parameter | vak                   |


### PR DESCRIPTION
The path doesn't take the student id parameter, so i removed it. 
Or im stupid ¯\\_(ツ)_/¯