### PR TITLE
Placed return between closing tag and undocumented

### DIFF
--- a/README.md
+++ b/README.md
@@ -1833,6 +1833,7 @@ Deletes the currently active icalendar stream
 NONE
 
 </details>
+
 ### Undocumented:
 
 - `GET /rest/v1/medewerkers/ontvangers`


### PR DESCRIPTION
This makes it show up as a heading.